### PR TITLE
moving interactive content out of interactive content

### DIFF
--- a/src/plugins/discover/public/application/components/sidebar/discover_field.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_field.tsx
@@ -175,28 +175,21 @@ export function DiscoverField({
   return (
     <>
       <EuiPopover
+        ownFocus
         display="block"
         button={
-          <EuiKeyboardAccessible>
-            <FieldButton
-              size="s"
-              className="dscSidebarItem"
-              isOpen={showDetails}
-              tabIndex={0}
-              onClick={() => {
-                togglePopover();
-              }}
-              onKeyPress={(event: any) => {
-                if (event.key === 'ENTER') {
-                  togglePopover();
-                }
-              }}
-              data-test-subj={`field-${field.name}-showDetails`}
-              fieldIcon={dscFieldIcon}
-              fieldAction={actionButton}
-              fieldName={fieldName}
-            />
-          </EuiKeyboardAccessible>
+          <FieldButton
+            size="s"
+            className="dscSidebarItem"
+            isOpen={showDetails}
+            onClick={() => {
+              togglePopover();
+            }}
+            data-test-subj={`field-${field.name}-showDetails`}
+            fieldIcon={dscFieldIcon}
+            fieldAction={actionButton}
+            fieldName={fieldName}
+          />
         }
         isOpen={infoIsOpen}
         closePopover={() => setOpen(false)}

--- a/src/plugins/discover/public/application/components/sidebar/discover_field.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_field.tsx
@@ -17,7 +17,13 @@
  * under the License.
  */
 import React, { useState } from 'react';
-import { EuiButton, EuiPopover, EuiPopoverTitle, EuiKeyboardAccessible } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiPopover,
+  EuiPopoverTitle,
+  EuiKeyboardAccessible,
+  EuiIcon,
+} from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import { DiscoverFieldDetails } from './discover_field_details';
 import { FieldIcon, FieldButton, FieldButtonProps } from '../../../../../kibana_react/public';

--- a/src/plugins/discover/public/application/components/sidebar/discover_field_details.tsx
+++ b/src/plugins/discover/public/application/components/sidebar/discover_field_details.tsx
@@ -72,10 +72,10 @@ export function DiscoverFieldDetails({
                 id="discover.fieldChooser.detailViews.visualizeLinkText"
                 defaultMessage="Visualize"
               />
-              {warnings.length > 0 && (
-                <EuiIconTip type="alert" color="warning" content={warnings.join(' ')} />
-              )}
             </EuiLink>
+            {warnings.length > 0 && (
+              <EuiIconTip type="alert" color="warning" content={warnings.join(' ')} />
+            )}
           </>
         )}
       </div>

--- a/src/plugins/kibana_react/public/field_button/field_button.scss
+++ b/src/plugins/kibana_react/public/field_button/field_button.scss
@@ -2,7 +2,8 @@
   @include euiFontSizeS;
   border-radius: $euiBorderRadius;
   margin-bottom: $euiSizeXS;
-  position: relative;
+  display: flex;
+  align-items: center;
 
   &:focus-within,
   .euiPopover-isOpen & {
@@ -66,14 +67,15 @@
   }
 }
 
-.kbnFieldButton__fieldAction,
-.kbnFieldButton__infoIcon {
-  position: absolute;
-  top: 50%;
-  right: $euiSizeS;
-  transform: translateY(-50%);
-}
+.kbnFieldButton__append {
+  padding-right: $euiSizeS;
+  display: flex;
 
-.kbnFieldButton__infoIcon + .kbnFieldButton__fieldAction {
-  right: $euiSizeS * 4;
+  .kbnFieldButton__fieldAction + .kbnFieldButton__infoIcon {
+    padding-left: $euiSizeXS;
+  }
+
+  .kbnFieldButton__infoIcon {
+    flex-shrink: 0;
+  }
 }

--- a/src/plugins/kibana_react/public/field_button/field_button.scss
+++ b/src/plugins/kibana_react/public/field_button/field_button.scss
@@ -3,6 +3,11 @@
   border-radius: $euiBorderRadius;
   margin-bottom: $euiSizeXS;
   position: relative;
+
+  &:focus-within,
+  .euiPopover-isOpen & {
+    @include euiFocusRing;
+  }
 }
 
 .kbnFieldButton--isDraggable {

--- a/src/plugins/kibana_react/public/field_button/field_button.scss
+++ b/src/plugins/kibana_react/public/field_button/field_button.scss
@@ -2,7 +2,7 @@
   @include euiFontSizeS;
   border-radius: $euiBorderRadius;
   margin-bottom: $euiSizeXS;
-  cursor: pointer;
+  position: relative;
 }
 
 .kbnFieldButton--isDraggable {
@@ -34,6 +34,8 @@
 }
 
 .kbnFieldButton__content {
+  width: 100%;
+  text-align: left;
   border-radius: $euiBorderRadius - 1px;
   padding: $euiSizeS;
   display: flex;
@@ -57,4 +59,12 @@
     margin-top: $euiSizeXS / 2;
     margin-right: $euiSizeXS / 2;
   }
+}
+
+.kbnFieldButton__fieldAction,
+.kbnFieldButton__infoIcon {
+  position: absolute;
+  top: 50%;
+  right: $euiSizeS;
+  transform: translateY(-50%);
 }

--- a/src/plugins/kibana_react/public/field_button/field_button.scss
+++ b/src/plugins/kibana_react/public/field_button/field_button.scss
@@ -68,3 +68,7 @@
   right: $euiSizeS;
   transform: translateY(-50%);
 }
+
+.kbnFieldButton__infoIcon + .kbnFieldButton__fieldAction {
+  right: $euiSizeS * 4;
+}

--- a/src/plugins/kibana_react/public/field_button/field_button.tsx
+++ b/src/plugins/kibana_react/public/field_button/field_button.tsx
@@ -16,11 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { ReactNode } from 'react';
-import classNames from 'classnames';
-import './field_button.scss';
 
-export interface FieldButtonProps {
+import classNames from 'classnames';
+import React, { ReactNode } from 'react';
+import './field_button.scss';
+import { OneOf } from '@elastic/eui';
+
+interface Props {
   isOpen?: boolean;
   fieldIcon?: ReactNode;
   fieldName?: ReactNode;
@@ -29,7 +31,10 @@ export interface FieldButtonProps {
   isDraggable?: boolean;
   size?: ButtonSize;
   className?: string;
+  onClick?: () => void;
 }
+
+export type FieldButtonProps = OneOf<Props, 'fieldInfoIcon' | 'fieldAction'>;
 
 /**
  * Wraps Object.keys with proper typescript definition of the resulting array
@@ -56,6 +61,7 @@ export function FieldButton({
   fieldAction,
   className,
   isDraggable = false,
+  onClick,
   ...rest
 }: FieldButtonProps) {
   const classes = classNames(
@@ -68,12 +74,12 @@ export function FieldButton({
 
   return (
     <div className={classes} {...rest}>
-      <div className="kbnFieldButton__content">
+      <button onClick={onClick} className="kbnFieldButton__content">
         <div className="kbnFieldButton__fieldIcon">{fieldIcon}</div>
         <div className="kbnFieldButton__name">{fieldName}</div>
-        <div className="kbnFieldButton__fieldAction">{fieldAction}</div>
-        <div className="kbnFieldButton__infoIcon">{fieldInfoIcon}</div>
-      </div>
+      </button>
+      {fieldAction && <div className="kbnFieldButton__fieldAction">{fieldAction}</div>}
+      {fieldInfoIcon && <div className="kbnFieldButton__infoIcon">{fieldInfoIcon}</div>}
     </div>
   );
 }

--- a/src/plugins/kibana_react/public/field_button/field_button.tsx
+++ b/src/plugins/kibana_react/public/field_button/field_button.tsx
@@ -72,12 +72,14 @@ export function FieldButton({
 
   return (
     <div className={classes} {...rest}>
-      <button onClick={onClick} className="kbnFieldButton__content">
+      <button onClick={onClick} className="kbn-resetFocusState kbnFieldButton__content">
         <div className="kbnFieldButton__fieldIcon">{fieldIcon}</div>
         <div className="kbnFieldButton__name">{fieldName}</div>
       </button>
-      {fieldInfoIcon && <div className="kbnFieldButton__infoIcon">{fieldInfoIcon}</div>}
-      {fieldAction && <div className="kbnFieldButton__fieldAction">{fieldAction}</div>}
+      <div className="kbnFieldButton__append">
+        {fieldAction && <div className="kbnFieldButton__fieldAction">{fieldAction}</div>}
+        {fieldInfoIcon && <div className="kbnFieldButton__infoIcon">{fieldInfoIcon}</div>}
+      </div>
     </div>
   );
 }

--- a/src/plugins/kibana_react/public/field_button/field_button.tsx
+++ b/src/plugins/kibana_react/public/field_button/field_button.tsx
@@ -22,7 +22,7 @@ import React, { ReactNode } from 'react';
 import './field_button.scss';
 import { OneOf } from '@elastic/eui';
 
-interface Props {
+export interface FieldButtonProps {
   isOpen?: boolean;
   fieldIcon?: ReactNode;
   fieldName?: ReactNode;
@@ -33,8 +33,6 @@ interface Props {
   className?: string;
   onClick?: () => void;
 }
-
-export type FieldButtonProps = OneOf<Props, 'fieldInfoIcon' | 'fieldAction'>;
 
 /**
  * Wraps Object.keys with proper typescript definition of the resulting array
@@ -78,8 +76,8 @@ export function FieldButton({
         <div className="kbnFieldButton__fieldIcon">{fieldIcon}</div>
         <div className="kbnFieldButton__name">{fieldName}</div>
       </button>
-      {fieldAction && <div className="kbnFieldButton__fieldAction">{fieldAction}</div>}
       {fieldInfoIcon && <div className="kbnFieldButton__infoIcon">{fieldInfoIcon}</div>}
+      {fieldAction && <div className="kbnFieldButton__fieldAction">{fieldAction}</div>}
     </div>
   );
 }

--- a/x-pack/plugins/lens/public/indexpattern_datasource/field_item.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/field_item.tsx
@@ -198,6 +198,7 @@ export const InnerFieldItem = function InnerFieldItem(props: FieldItemProps) {
   );
   return (
     <EuiPopover
+      ownFocus
       id="lnsFieldListPanel__field"
       className="lnsFieldItem__popoverAnchor"
       display="block"

--- a/x-pack/plugins/lens/public/indexpattern_datasource/field_item.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/field_item.tsx
@@ -212,30 +212,23 @@ export const InnerFieldItem = function InnerFieldItem(props: FieldItemProps) {
             exists ? 'exists' : 'missing'
           }`}
         >
-          <EuiKeyboardAccessible>
-            <FieldButton
-              className="lnsFieldItem__info"
-              isDraggable
-              isOpen={infoIsOpen}
-              data-test-subj={`lnsFieldListPanelField-${field.name}`}
-              onClick={() => {
-                if (exists) {
-                  togglePopover();
-                }
-              }}
-              onKeyPress={(event) => {
-                if (exists && event.key === 'ENTER') {
-                  togglePopover();
-                }
-              }}
-              aria-label={i18n.translate('xpack.lens.indexPattern.fieldStatsButtonLabel', {
-                defaultMessage: 'Click for a field preview, or drag and drop to visualize.',
-              })}
-              fieldInfoIcon={lensInfoIcon}
-              fieldIcon={lensFieldIcon}
-              fieldName={wrappableHighlightableFieldName}
-            />
-          </EuiKeyboardAccessible>
+          <FieldButton
+            className="lnsFieldItem__info"
+            isDraggable
+            isOpen={infoIsOpen}
+            data-test-subj={`lnsFieldListPanelField-${field.name}`}
+            onClick={() => {
+              if (exists) {
+                togglePopover();
+              }
+            }}
+            aria-label={i18n.translate('xpack.lens.indexPattern.fieldStatsButtonLabel', {
+              defaultMessage: 'Click for a field preview, or drag and drop to visualize.',
+            })}
+            fieldInfoIcon={lensInfoIcon}
+            fieldIcon={lensFieldIcon}
+            fieldName={wrappableHighlightableFieldName}
+          />
         </DragDrop>
       }
       isOpen={infoIsOpen}


### PR DESCRIPTION
Previously, there were a few places that had nested interactive content which can cause problems with keyboard navigation and screen readers. 

This PR moves that content out to be siblings with each other and tried to preserve the styles as best I could. 

One thing that I can't figure out is in the EUI docs, `EuiIconTip` is a tabbable element but it's not within Kibana. @andreadelrio Do you have any idea why? 