### PR TITLE
Moving `kbnFieldButton__infoIcon` into `<button>`

### DIFF
--- a/src/plugins/kibana_react/public/field_button/__snapshots__/field_button.test.tsx.snap
+++ b/src/plugins/kibana_react/public/field_button/__snapshots__/field_button.test.tsx.snap
@@ -4,8 +4,8 @@ exports[`isDraggable is rendered 1`] = `
 <div
   className="kbnFieldButton kbnFieldButton--isDraggable"
 >
-  <div
-    className="kbnFieldButton__content"
+  <button
+    className="kbn-resetFocusState kbnFieldButton__content"
   >
     <div
       className="kbnFieldButton__fieldIcon"
@@ -13,13 +13,10 @@ exports[`isDraggable is rendered 1`] = `
     <div
       className="kbnFieldButton__name"
     />
-    <div
-      className="kbnFieldButton__fieldAction"
-    />
-    <div
-      className="kbnFieldButton__infoIcon"
-    />
-  </div>
+  </button>
+  <div
+    className="kbnFieldButton__append"
+  />
 </div>
 `;
 
@@ -27,8 +24,8 @@ exports[`sizes m is applied 1`] = `
 <div
   className="kbnFieldButton"
 >
-  <div
-    className="kbnFieldButton__content"
+  <button
+    className="kbn-resetFocusState kbnFieldButton__content"
   >
     <div
       className="kbnFieldButton__fieldIcon"
@@ -36,13 +33,10 @@ exports[`sizes m is applied 1`] = `
     <div
       className="kbnFieldButton__name"
     />
-    <div
-      className="kbnFieldButton__fieldAction"
-    />
-    <div
-      className="kbnFieldButton__infoIcon"
-    />
-  </div>
+  </button>
+  <div
+    className="kbnFieldButton__append"
+  />
 </div>
 `;
 
@@ -50,8 +44,8 @@ exports[`sizes s is applied 1`] = `
 <div
   className="kbnFieldButton kbnFieldButton--small"
 >
-  <div
-    className="kbnFieldButton__content"
+  <button
+    className="kbn-resetFocusState kbnFieldButton__content"
   >
     <div
       className="kbnFieldButton__fieldIcon"
@@ -59,12 +53,9 @@ exports[`sizes s is applied 1`] = `
     <div
       className="kbnFieldButton__name"
     />
-    <div
-      className="kbnFieldButton__fieldAction"
-    />
-    <div
-      className="kbnFieldButton__infoIcon"
-    />
-  </div>
+  </button>
+  <div
+    className="kbnFieldButton__append"
+  />
 </div>
 `;

--- a/src/plugins/kibana_react/public/field_button/field_button.scss
+++ b/src/plugins/kibana_react/public/field_button/field_button.scss
@@ -4,6 +4,8 @@
   margin-bottom: $euiSizeXS;
   display: flex;
   align-items: center;
+  transition: box-shadow $euiAnimSpeedFast $euiAnimSlightResistance,
+              background-color $euiAnimSpeedFast $euiAnimSlightResistance; // sass-lint:disable-line indentation
 
   &:focus-within,
   &-isActive {
@@ -22,7 +24,7 @@
     z-index: 2;
   }
 
-  .kbnFieldButton__content {
+  .kbnFieldButton__button {
     &:hover,
     &:focus {
       cursor: grab;
@@ -30,43 +32,44 @@
   }
 }
 
-.kbnFieldButton--small {
-  font-size: $euiFontSizeXS;
-}
-
-.kbnFieldButton__content {
-  width: 100%;
+.kbnFieldButton__button {
+  flex-grow: 1;
   text-align: left;
-  border-radius: $euiBorderRadius - 1px;
-  padding: $euiSizeS 0 $euiSizeS $euiSizeS;
+  padding: $euiSizeS;
   display: flex;
   align-items: flex-start;
-  transition: box-shadow $euiAnimSpeedFast $euiAnimSlightResistance,
-    background-color $euiAnimSpeedFast $euiAnimSlightResistance; // sass-lint:disable-line indentation
-
-  .kbnFieldButton__name {
-    margin-left: $euiSizeS;
-    flex-grow: 1;
-    word-break: break-word;
-    padding-right: 1px;
-  }
-
-  .kbnFieldButton__fieldIcon {
-    flex-shrink: 0;
-    margin-top: 0;
-    margin-right: $euiSizeXS / 2;
-  }
 }
 
-.kbnFieldButton__append {
-  padding-right: $euiSizeS;
-  display: flex;
+.kbnFieldButton__fieldIcon {
+  flex-shrink: 0;
+  line-height: 0;
+  margin-right: $euiSizeS;
+}
 
-  .kbnFieldButton__fieldAction + .kbnFieldButton__infoIcon {
-    padding-left: $euiSizeXS;
+.kbnFieldButton__name {
+  flex-grow: 1;
+  word-break: break-word;
+}
+
+.kbnFieldButton__infoIcon {
+  flex-shrink: 0;
+  margin-left: $euiSizeXS;
+}
+
+.kbnFieldButton__fieldAction {
+  margin-right: $euiSizeS;
+}
+
+// Reduce text size and spacing for the small size
+.kbnFieldButton--small {
+  font-size: $euiFontSizeXS;
+
+  .kbnFieldButton__button {
+    padding: $euiSizeXS;
   }
 
-  .kbnFieldButton__infoIcon {
-    flex-shrink: 0;
+  .kbnFieldButton__fieldIcon,
+  .kbnFieldButton__fieldAction {
+    margin-right: $euiSizeXS;
   }
 }

--- a/src/plugins/kibana_react/public/field_button/field_button.scss
+++ b/src/plugins/kibana_react/public/field_button/field_button.scss
@@ -56,8 +56,7 @@
     padding-right: 1px;
   }
 
-  .kbnFieldButton__fieldIcon,
-  .kbnFieldButton__infoIcon {
+  .kbnFieldButton__fieldIcon {
     flex-shrink: 0;
   }
 

--- a/src/plugins/kibana_react/public/field_button/field_button.tsx
+++ b/src/plugins/kibana_react/public/field_button/field_button.tsx
@@ -19,18 +19,47 @@
 
 import './field_button.scss';
 import classNames from 'classnames';
-import React, { ReactNode } from 'react';
+import React, { ReactNode, HTMLAttributes, ButtonHTMLAttributes } from 'react';
 
-export interface FieldButtonProps {
-  isActive?: boolean;
-  fieldIcon?: ReactNode;
+export interface FieldButtonProps extends HTMLAttributes<HtmlDivElement> {
+  /**
+   * Label for the button
+   */
   fieldName: ReactNode;
+  /**
+   * Icon representing the field type.
+   * Recommend using FieldIcon
+   */
+  fieldIcon?: ReactNode;
+  /**
+   * An optional node to place inside and at the end of the <button>
+   */
   fieldInfoIcon?: ReactNode;
+  /**
+   * An optional node to place outside of and to the right of the <button>
+   */
   fieldAction?: ReactNode;
+  /**
+   * Adds a forced focus ring to the whole component
+   */
+  isActive?: boolean;
+  /**
+   * Styles the component differently to indicate it is draggable
+   */
   isDraggable?: boolean;
+  /**
+   * Use the small size in condensed areas
+   */
   size?: ButtonSize;
   className?: string;
-  onClick?: () => void;
+  /**
+   * The component always renders a `<button>` and therefore will always need an `onClick`
+   */
+  onClick: () => void;
+  /**
+   * Pass more button props to the actual `<button>` element
+   */
+  buttonProps: ButtonHTMLAttributes<HTMLButtonElement>;
 }
 
 /**
@@ -59,6 +88,7 @@ export function FieldButton({
   className,
   isDraggable = false,
   onClick,
+  buttonProps,
   ...rest
 }: FieldButtonProps) {
   const classes = classNames(
@@ -69,16 +99,19 @@ export function FieldButton({
     className
   );
 
+  const buttonClasses = classNames(
+    'kbn-resetFocusState kbnFieldButton__button',
+    buttonProps && buttonProps.className
+  );
+
   return (
     <div className={classes} {...rest}>
-      <button onClick={onClick} className="kbn-resetFocusState kbnFieldButton__content">
+      <button onClick={onClick} {...buttonProps} className={buttonClasses}>
         {fieldIcon && <span className="kbnFieldButton__fieldIcon">{fieldIcon}</span>}
         {fieldName && <span className="kbnFieldButton__name">{fieldName}</span>}
-      </button>
-      <div className="kbnFieldButton__append">
-        {fieldAction && <div className="kbnFieldButton__fieldAction">{fieldAction}</div>}
         {fieldInfoIcon && <div className="kbnFieldButton__infoIcon">{fieldInfoIcon}</div>}
-      </div>
+      </button>
+      {fieldAction && <div className="kbnFieldButton__fieldAction">{fieldAction}</div>}
     </div>
   );
 }

--- a/src/plugins/kibana_react/public/field_button/field_button.tsx
+++ b/src/plugins/kibana_react/public/field_button/field_button.tsx
@@ -20,7 +20,6 @@
 import classNames from 'classnames';
 import React, { ReactNode } from 'react';
 import './field_button.scss';
-import { OneOf } from '@elastic/eui';
 
 export interface FieldButtonProps {
   isOpen?: boolean;

--- a/x-pack/plugins/lens/public/indexpattern_datasource/field_item.tsx
+++ b/x-pack/plugins/lens/public/indexpattern_datasource/field_item.tsx
@@ -222,12 +222,16 @@ export const InnerFieldItem = function InnerFieldItem(props: FieldItemProps) {
                 togglePopover();
               }
             }}
-            aria-label={i18n.translate('xpack.lens.indexPattern.fieldStatsButtonLabel', {
-              defaultMessage: 'Click for a field preview, or drag and drop to visualize.',
+            aria-label={i18n.translate('xpack.lens.indexPattern.fieldStatsButtonAriaLabel', {
+              defaultMessage: '{fieldName}: {fieldType}. Hit enter for a field preview.',
+              values: {
+                fieldName: field.name,
+                fieldType: field.type,
+              },
             })}
-            fieldInfoIcon={lensInfoIcon}
             fieldIcon={lensFieldIcon}
             fieldName={wrappableHighlightableFieldName}
+            fieldInfoIcon={lensInfoIcon}
           />
         </DragDrop>
       }


### PR DESCRIPTION
And adding a few props and prop comments, and reducing sizing of small buttons.

This does not completely solve the case for a sighted, but keyboard-using user (without screen reader). But this doesn't hinder us from getting there and I think we need more support from the EuiTooltip component to get us there (ie being able to say `onFocusOnly`).

This isn't a degraded experience for those users compared to master, so in order to push along the original intent of the PR, I'd opt that we circle back to the sighted, but keyboard-using user experience.