### PR TITLE
[Discover] Add field types in-product help: Scrolling instead of pagination

### DIFF
--- a/src/plugins/discover/public/application/main/components/sidebar/discover_field_search.tsx
+++ b/src/plugins/discover/public/application/main/components/sidebar/discover_field_search.tsx
@@ -31,6 +31,8 @@ import {
   EuiPagination,
   EuiBasicTableColumn,
   EuiLink,
+  EuiText,
+  EuiPanel,
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { FieldIcon } from '@kbn/react-field';
@@ -370,27 +372,36 @@ export function DiscoverFieldSearch({ onChange, value, types, presentFieldTypes 
             display="block"
             button={helpButton}
             isOpen={isHelpOpen}
-            panelPaddingSize="m"
+            panelPaddingSize="none"
             className="dscFieldTypesHelp__popover"
             panelClassName="dscFieldTypesHelp__panel"
             closePopover={closeHelp}
+            initialFocus="#dscFieldTypesHelpBasicTableId"
           >
             <EuiPopoverTitle paddingSize="s">
               {i18n.translate('discover.fieldChooser.popoverTitle', {
                 defaultMessage: 'Field types',
               })}
             </EuiPopoverTitle>
-            <EuiBasicTable
-              tableCaption={i18n.translate('discover.fieldTypesPopover.tableTitle', {
-                defaultMessage: 'Description of field types',
-              })}
-              items={items}
-              compressed={true}
-              rowHeader="firstName"
-              columns={columnsSidebar}
-              responsive={false}
-            />
-            <EuiSpacer size="s" />
+            <EuiPanel
+              className="eui-yScroll"
+              style={{ maxHeight: '50vh' }}
+              color="transparent"
+              paddingSize="s"
+            >
+              <EuiBasicTable
+                id="dscFieldTypesHelpBasicTableId"
+                tableCaption={i18n.translate('discover.fieldTypesPopover.tableTitle', {
+                  defaultMessage: 'Description of field types',
+                })}
+                items={items}
+                compressed={true}
+                rowHeader="firstName"
+                columns={columnsSidebar}
+                responsive={false}
+              />
+            </EuiPanel>
+            {/* <EuiSpacer size="s" />
             {presentFieldTypes.length > FIELD_TYPES_PER_PAGE && (
               <EuiFlexGroup justifyContent="flexEnd" gutterSize="none" responsive={false}>
                 <EuiFlexItem grow={false}>
@@ -404,16 +415,20 @@ export function DiscoverFieldSearch({ onChange, value, types, presentFieldTypes 
                   />
                 </EuiFlexItem>
               </EuiFlexGroup>
-            )}
-            <EuiPopoverFooter paddingSize="s">
-              Learn more about&nbsp;
-              <EuiLink href={docLinks.links.discover.fieldTypeHelp}>
-                <FormattedMessage
-                  id="discover.fieldTypesPopover.learnMore"
-                  defaultMessage="field types"
-                />
-              </EuiLink>
-            </EuiPopoverFooter>
+            )} */}
+            <EuiPanel color="transparent" paddingSize="s">
+              <EuiText color="subdued" size="xs">
+                <p>
+                  Learn more about&nbsp;
+                  <EuiLink href={docLinks.links.discover.fieldTypeHelp}>
+                    <FormattedMessage
+                      id="discover.fieldTypesPopover.learnMore"
+                      defaultMessage="field types"
+                    />
+                  </EuiLink>
+                </p>
+              </EuiText>
+            </EuiPanel>
           </EuiPopover>
         </EuiFilterGroup>
       </EuiFlexItem>


### PR DESCRIPTION
@andreadelrio 

As I mentioned in your PR, this is an example of how to easily get the popover contents to scroll. I've maxed the height at `50vh` so that it can grow pretty tall based on the user's browser height.

I also adjusted the padding around the table using an EuiPanel to add that and the scroll. Then used another similar panel as the footer wrapper so there weren't two borders near eachother. 

My nit-picks were just subduing that footer text a bit, and I added a `initialFocus` prop to the EuiPopover so that it will auto-focus the table instead of the first link (which is in the footer).

I only commented out the pagination for now so you can see what has changed.