### PR TITLE
Update title on Canvas share on website flyout

### DIFF
--- a/x-pack/plugins/canvas/public/components/workpad_header/share_menu/flyout/flyout.component.tsx
+++ b/x-pack/plugins/canvas/public/components/workpad_header/share_menu/flyout/flyout.component.tsx
@@ -61,7 +61,7 @@ const strings = {
     }),
   getTitle: () =>
     i18n.translate('xpack.canvas.shareWebsiteFlyout.flyoutTitle', {
-      defaultMessage: 'Share on a website',
+      defaultMessage: 'Embed code',
     }),
   getUnsupportedRendererWarning: () =>
     i18n.translate('xpack.canvas.workpadHeaderShareMenu.unsupportedRendererWarning', {

--- a/x-pack/plugins/canvas/shareable_runtime/README.mdx
+++ b/x-pack/plugins/canvas/shareable_runtime/README.mdx
@@ -15,7 +15,7 @@ This directory contains the code necessary to build and test this runtime.
 ## Quick Start
 
 - Load a workpad in Canvas.
-- Click "Export" -> "Share on a website" -> "download a ZIP file"
+- Click "Export" -> "Embed code" -> "download a ZIP file"
 - Extract and change to the extracted directory.
 - On your local machine:
   - Start a web server, like: `python -m SimpleHTTPServer 9001`
@@ -137,7 +137,7 @@ You can test this functionality in a number of ways. The easiest would be:
 ### Download a ZIP from Canvas
 
 - Load a workpad in Canvas.
-- Click "Export" -> "Share on a website" -> "download a ZIP file"
+- Click "Export" -> "Embed code" -> "download a ZIP file"
 - Extract and change to the extracted directory.
 - Start a web server, like: `python -m SimpleHTTPServer 9001`
 - Open a web browser to `http://localhost:9001`
@@ -145,7 +145,7 @@ You can test this functionality in a number of ways. The easiest would be:
 ### Test the Runtime Directly from Webpack
 
 - Load a workpad in Canvas.
-- Click "Export" -> "Share on a website" -> "Download Workpad"
+- Click "Export" -> "Embed code" -> "Download Workpad"
 - Copy the workpad to `canvas/shareable_runtime/test`.
 - Edit `canvas/shareable_runtime/index.html` to include your workpad.
 - From `/canvas`, run `node scripts/shareable_runtime --run`

--- a/x-pack/plugins/translations/translations/ja-JP.json
+++ b/x-pack/plugins/translations/translations/ja-JP.json
@@ -8848,7 +8848,6 @@
     "xpack.canvas.savedElementsModal.modalTitle": "マイエレメント",
     "xpack.canvas.shareWebsiteFlyout.description": "外部 Web サイトでこのワークパッドの不動バージョンを共有するには、これらの手順に従ってください。現在のワークパッドのビジュアルスナップショットになり、ライブデータにはアクセスできません。",
     "xpack.canvas.shareWebsiteFlyout.flyoutCalloutDescription": "共有するには、このワークパッド、{CANVAS} シェアラブルワークパッドランタイム、サンプル {HTML} ファイルを含む {link} を使用します。",
-    "xpack.canvas.shareWebsiteFlyout.flyoutTitle": "Webサイトで共有",
     "xpack.canvas.shareWebsiteFlyout.runtimeStep.description": "共有可能なワークパッドをレンダリングするには、{CANVAS} シェアラブルワークパッドランタイムも含める必要があります。Web サイトにすでにランタイムが含まれている場合、この手順をスキップすることができます。",
     "xpack.canvas.shareWebsiteFlyout.runtimeStep.downloadLabel": "ダウンロードランタイム",
     "xpack.canvas.shareWebsiteFlyout.snippetsStep.addSnippetsTitle": "スナップショットを Web サイトに追加",

--- a/x-pack/plugins/translations/translations/zh-CN.json
+++ b/x-pack/plugins/translations/translations/zh-CN.json
@@ -8869,7 +8869,6 @@
     "xpack.canvas.savedElementsModal.modalTitle": "我的元素",
     "xpack.canvas.shareWebsiteFlyout.description": "按照以下步骤在外部网站上共享此 Workpad 的静态版本。其将是当前 Workpad 的可视化快照，对实时数据没有访问权限。",
     "xpack.canvas.shareWebsiteFlyout.flyoutCalloutDescription": "要尝试共享，可以{link}，其包含此 Workpad、{CANVAS} Shareable Workpad Runtime 及示例 {HTML} 文件。",
-    "xpack.canvas.shareWebsiteFlyout.flyoutTitle": "在网站上共享",
     "xpack.canvas.shareWebsiteFlyout.runtimeStep.description": "要呈现可共享 Workpad，还需要加入 {CANVAS} Shareable Workpad Runtime。如果您的网站已包含该运行时，则可以跳过此步骤。",
     "xpack.canvas.shareWebsiteFlyout.runtimeStep.downloadLabel": "下载运行时",
     "xpack.canvas.shareWebsiteFlyout.snippetsStep.addSnippetsTitle": "将代码段添加到网站",


### PR DESCRIPTION
## Summary

This changes the title on the share on website flyout from "Share on a website" to "Embed code" to align with share menu updates.

### Checklist

Use ~~strikethroughs~~ to remove checklist items you don't feel are applicable to this PR.

- [ ] This was checked for cross-browser compatibility, [including a check against IE11](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility)
- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#writing-documentation) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#cross-browser-compatibility) were updated or added to match the most common scenarios
- [ ] This was checked for [keyboard-only and screenreader accessibility](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Accessibility#Accessibility_testing_checklist)

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)
- [ ] This includes a feature addition or change that requires a release note and was [labeled appropriately](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md#release-notes-process)

